### PR TITLE
Add WASM files to exports in order to avoid compilation errors with esbuild & yarn pnp

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
   "exports": {
     ".": "./dist/full/index.js",
     "./reader": "./dist/reader/index.js",
+    "./reader/zxing_reader.wasm": "./dist/reader/zxing_reader.wasm",
     "./writer": "./dist/writer/index.js",
-    "./full": "./dist/full/index.js"
+    "./writer/zxing_writer.wasm": "./dist/writer/zxing_writer.wasm",
+    "./full": "./dist/full/index.js",
+    "./full/zxing_full.wasm": "./dist/full/zxing_full.wasm"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for the work put into this, it works like a charm! 

... up to the moment where I want to avoid downloading the WASM file from the internet, where my `esbuild` gives me an error:

```
The path "./reader/zxing_reader.wasm" is not exported by package "zxing-wasm"
```

This is what I'm fixing with this MR.

**Edit**: It's in fact only `esbuild --bundle` mode that triggers the error.