### PR TITLE
chore: bump zxing-cpp to b3aff4a

### DIFF
--- a/.changeset/grumpy-impalas-learn.md
+++ b/.changeset/grumpy-impalas-learn.md
@@ -1,0 +1,11 @@
+---
+"zxing-wasm": patch
+---
+
+Bump zxing-cpp to `b3aff4a`:
+
+- Deprecate `validateCode39CheckSum`, `validateITFCheckSum` and `returnCodabarStartEnd`. Related commits from upstream: [`fc8f32d`](https://github.com/zxing-cpp/zxing-cpp/commit/fc8f32d7db00060b3aab24338c08ab792cef0bfd), [`b3fe574`](https://github.com/zxing-cpp/zxing-cpp/commit/b3fe5744b2a0ac554efa70635a087c5ff3342c42), [`d636c6d`](https://github.com/zxing-cpp/zxing-cpp/commit/d636c6d8a054fe5d794e9ed57159a5230ad6ebf5) [`68c97c7`](https://github.com/zxing-cpp/zxing-cpp/commit/68c97c744f2fe1ead3677dd106020530d44d7180), [`2f3c72c`](https://github.com/zxing-cpp/zxing-cpp/commit/2f3c72cccea22a60d41b31c185aba1ea5425d6bb).
+
+- Reduce WASM binaries size. Related commits from upstream: [`6741403`](https://github.com/zxing-cpp/zxing-cpp/commit/67414033f8cc28d7152c3cdf2bb1562078b03c4f), [`1fa0070`](https://github.com/zxing-cpp/zxing-cpp/commit/1fa0070450437badab7ae6dcb1c1e80d7911d8e7), [`b3aff4a`](https://github.com/zxing-cpp/zxing-cpp/commit/b3aff4a98b03e056a244ca385a8221c50d67e352).
+
+- Other fixes and improvements from upstream.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,5 @@ updates:
           - "major"
     ignore:
       - dependency-name: "@biomejs/biome"
+      - dependency-name: "vite"
+        versions: ["5.x"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This package exports 3 subpaths: `full`, `reader` and `writer`. You can choose w
 
 ### `zxing-wasm` or `zxing-wasm/full`
 
-These 2 subpaths include functions to both read and write barcodes. The wasm binary size is ~1.17 MB.
+These 2 subpaths include functions to both read and write barcodes. The wasm binary size is ~1.06 MB.
 
 ```ts
 import {
@@ -65,7 +65,7 @@ import {
 
 ### `zxing-wasm/reader`
 
-This subpath only includes functions to read barcodes. The wasm binary size is ~930 KB.
+This subpath only includes functions to read barcodes. The wasm binary size is ~831 KB.
 
 ```ts
 import {
@@ -76,7 +76,7 @@ import {
 
 ### `zxing-wasm/writer`
 
-This subpath only includes a function to write barcodes. The wasm binary size is ~330 KB.
+This subpath only includes a function to write barcodes. The wasm binary size is ~313 KB.
 
 ```ts
 import { writeBarcodeToImageFile } from "zxing-wasm/writer";

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@biomejs/biome": "1.5.3",
         "@changesets/cli": "^2.27.1",
         "@types/babel__core": "^7.20.5",
-        "@types/node": "^20.11.19",
+        "@types/node": "^20.11.20",
         "concurrently": "^8.2.2",
         "copy-files-from-to": "^3.9.1",
         "lint-staged": "^15.2.2",
@@ -28,7 +28,7 @@
         "tsx": "^4.7.1",
         "typedoc": "^0.25.8",
         "typescript": "^5.3.3",
-        "vite": "~5.1.3",
+        "vite": "~5.0.12",
         "vite-plugin-babel": "^1.2.0"
       }
     },
@@ -1947,9 +1947,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
-      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+      "version": "20.11.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
+      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -8959,13 +8959,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.3.tgz",
-      "integrity": "sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
-        "postcss": "^8.4.35",
+        "postcss": "^8.4.32",
         "rollup": "^4.2.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@biomejs/biome": "1.5.3",
     "@changesets/cli": "^2.27.1",
     "@types/babel__core": "^7.20.5",
-    "@types/node": "^20.11.19",
+    "@types/node": "^20.11.20",
     "concurrently": "^8.2.2",
     "copy-files-from-to": "^3.9.1",
     "lint-staged": "^15.2.2",
@@ -110,7 +110,7 @@
     "tsx": "^4.7.1",
     "typedoc": "^0.25.8",
     "typescript": "^5.3.3",
-    "vite": "~5.1.3",
+    "vite": "~5.0.12",
     "vite-plugin-babel": "^1.2.0"
   },
   "dependencies": {

--- a/src/bindings/readerOptions.ts
+++ b/src/bindings/readerOptions.ts
@@ -90,18 +90,21 @@ export interface ZXingReaderOptions {
    * Assume Code-39 codes employ a check digit and validate it.
    *
    * @defaultValue `false`
+   * @deprecated upstream
    */
   validateCode39CheckSum: boolean;
   /**
    * Assume ITF codes employ a GS1 check digit and validate it.
    *
    * @defaultValue `false`
+   * @deprecated upstream
    */
   validateITFCheckSum: boolean;
   /**
    * If `true`, return the start and end chars in a Codabar barcode instead of stripping them.
    *
    * @defaultValue `false`
+   * @deprecated upstream
    */
   returnCodabarStartEnd: boolean;
   /**

--- a/src/cpp/ZXingWasm.cpp
+++ b/src/cpp/ZXingWasm.cpp
@@ -194,7 +194,7 @@ JsReadResults readBarcodesFromPixmap(
     {reinterpret_cast<uint8_t *>(bufferPtr),
      imgWidth,
      imgHeight,
-     ZXing::ImageFormat::RGBX},
+     ZXing::ImageFormat::RGBA},
     jsReaderOptions
   );
 }


### PR DESCRIPTION
- Deprecate `validateCode39CheckSum`, `validateITFCheckSum` and `returnCodabarStartEnd`.
- Reduce WASM binaries size.
- Other fixes and improvements from upstream.