### PR TITLE
fix: patch emscripten

### DIFF
--- a/.changeset/fair-carrots-serve.md
+++ b/.changeset/fair-carrots-serve.md
@@ -1,0 +1,5 @@
+---
+"zxing-wasm": patch
+---
+
+Patch emscripten to mitigate DOM Clobbering vulnerability.

--- a/.github/actions/setup-emsdk/action.yml
+++ b/.github/actions/setup-emsdk/action.yml
@@ -24,3 +24,10 @@ runs:
       with:
         version: ${{ inputs.emsdk-version }}
         actions-cache-folder: ${{ inputs.emsdk-cache-dir }}
+
+    - name: Patch emscripten
+      shell: bash
+      # You need to checkout the zxing-wasm repo first!
+      run: |
+        git apply ./emscripten.patch --unsafe-paths --directory="$(dirname $(which emcc))" --check --stat -v
+        git apply ./emscripten.patch --unsafe-paths --directory="$(dirname $(which emcc))"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   emsdk-version:
     description: EMSDK Version
     required: true
-    default: 3.1.64
+    default: 3.1.68
   emsdk-cache-dir:
     description: EMSDK Cache Directory
     required: true

--- a/emscripten.patch
+++ b/emscripten.patch
@@ -1,0 +1,48 @@
+diff --git a/src/shell.js b/src/shell.js
+index b8c9f7185..f760f752f 100644
+--- a/src/shell.js
++++ b/src/shell.js
+@@ -175,7 +175,7 @@ var quit_ = (status, toThrow) => {
+ #if SHARED_MEMORY && !MODULARIZE
+ // In MODULARIZE mode _scriptName needs to be captured already at the very top of the page immediately when the page is parsed, so it is generated there
+ // before the page load. In non-MODULARIZE modes generate it here.
+-var _scriptName = (typeof document != 'undefined') ? document.currentScript?.src : undefined;
++var _scriptName = (typeof document != 'undefined' && document.currentScript?.tagName.toUpperCase() === 'SCRIPT') ? document.currentScript.src : undefined;
+ 
+ #if ENVIRONMENT_MAY_BE_NODE
+ if (ENVIRONMENT_IS_NODE) {
+@@ -375,7 +375,7 @@ if (ENVIRONMENT_IS_SHELL) {
+ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
+   if (ENVIRONMENT_IS_WORKER) { // Check worker, not web, since window could be polyfilled
+     scriptDirectory = self.location.href;
+-  } else if (typeof document != 'undefined' && document.currentScript) { // web
++  } else if (typeof document != 'undefined' && document.currentScript?.tagName.toUpperCase() === 'SCRIPT') { // web
+     scriptDirectory = document.currentScript.src;
+   }
+ #if MODULARIZE
+diff --git a/src/shell_minimal.js b/src/shell_minimal.js
+index 756784324..77225acce 100644
+--- a/src/shell_minimal.js
++++ b/src/shell_minimal.js
+@@ -143,7 +143,7 @@ var ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && self.name == 'em-pthread';
+ #if !MODULARIZE
+ // In MODULARIZE mode _scriptName needs to be captured already at the very top of the page immediately when the page is parsed, so it is generated there
+ // before the page load. In non-MODULARIZE modes generate it here.
+-var _scriptName = (typeof document != 'undefined') ? document.currentScript?.src : undefined;
++var _scriptName = (typeof document != 'undefined' && document.currentScript?.tagName.toUpperCase() === 'SCRIPT') ? document.currentScript.src : undefined;
+ #endif
+ 
+ #if ENVIRONMENT_MAY_BE_NODE
+diff --git a/tools/link.py b/tools/link.py
+index b7cb3c77d..f869ea991 100644
+--- a/tools/link.py
++++ b/tools/link.py
+@@ -2414,7 +2414,7 @@ def modularize():
+     if settings.EXPORT_ES6 and settings.USE_ES6_IMPORT_META:
+       script_url = 'import.meta.url'
+     else:
+-      script_url = "typeof document != 'undefined' ? document.currentScript?.src : undefined"
++      script_url = "(typeof document != 'undefined' && document.currentScript?.tagName.toUpperCase() === 'SCRIPT') ? document.currentScript.src : undefined"
+       if shared.target_environment_may_be('node'):
+         script_url_node = "if (typeof __filename != 'undefined') _scriptName = _scriptName || __filename;"
+     src = '''%(node_imports)s


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new step to patch Emscripten during the setup process.

- **Changes**
	- Updated EMSDK setup to use a fixed version instead of a dynamic input.
	- Disabled caching for the EMSDK setup process.
	- Updated the default EMSDK version to 3.1.68 for the Setup action.

- **Improvements**
	- Enhanced script name retrieval logic to ensure it only captures valid script tags in JavaScript and Python files.
	- Added a patch for the "zxing-wasm" component to mitigate a DOM Clobbering vulnerability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->