### PR TITLE
fix: bump zxing-cpp to `aab9ccc` to return position info from pure MaxiCodes

### DIFF
--- a/.changeset/silver-webs-behave.md
+++ b/.changeset/silver-webs-behave.md
@@ -1,0 +1,5 @@
+---
+"zxing-wasm": patch
+---
+
+Bump zxing-cpp to `aab9ccc` to return position info from pure MaxiCodes.

--- a/package.json
+++ b/package.json
@@ -190,11 +190,11 @@
     "@babel/core": "^7.27.1",
     "@babel/types": "^7.27.1",
     "@biomejs/biome": "1.9.4",
-    "@changesets/cli": "^2.29.3",
+    "@changesets/cli": "^2.29.4",
     "@napi-rs/canvas": "^0.1.70",
     "@types/babel__core": "^7.20.5",
-    "@types/node": "^22.15.12",
-    "@vitest/ui": "^3.1.3",
+    "@types/node": "^22.15.21",
+    "@vitest/ui": "^3.1.4",
     "concurrently": "^9.1.2",
     "copy-files-from-to": "^3.12.1",
     "jimp": "^1.6.0",
@@ -210,7 +210,7 @@
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vite-plugin-babel": "^1.3.1",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.4"
   },
   "dependencies": {
     "@types/emscripten": "^1.40.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@changesets/cli':
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^2.29.4
+        version: 2.29.4
       '@napi-rs/canvas':
         specifier: ^0.1.70
         version: 0.1.70
@@ -34,11 +34,11 @@ importers:
         specifier: ^7.20.5
         version: 7.20.5
       '@types/node':
-        specifier: ^22.15.12
-        version: 22.15.12
+        specifier: ^22.15.21
+        version: 22.15.21
       '@vitest/ui':
-        specifier: ^3.1.3
-        version: 3.1.3(vitest@3.1.3)
+        specifier: ^3.1.4
+        version: 3.1.4(vitest@3.1.4)
       concurrently:
         specifier: ^9.1.2
         version: 9.1.2
@@ -80,13 +80,13 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+        version: 6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       vite-plugin-babel:
         specifier: ^1.3.1
-        version: 1.3.1(@babel/core@7.27.1)(vite@6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+        version: 1.3.1(@babel/core@7.27.1)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       vitest:
-        specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.12)(@vitest/ui@3.1.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+        specifier: ^3.1.4
+        version: 3.1.4(@types/node@22.15.21)(@vitest/ui@3.1.4)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
 packages:
 
@@ -217,14 +217,14 @@ packages:
   '@changesets/apply-release-plan@7.0.12':
     resolution: {integrity: sha512-EaET7As5CeuhTzvXTQCRZeBUcisoYPDDcXvgTE/2jmmypKp0RC7LxKj/yzqeh/1qFTZI7oDGFcL1PHRuQuketQ==}
 
-  '@changesets/assemble-release-plan@6.0.7':
-    resolution: {integrity: sha512-vS5J92Rm7ZUcrvtu6WvggGWIdohv8s1/3ypRYQX8FsPO+KPDx6JaNC3YwSfh2umY/faGGfNnq42A7PRT0aZPFw==}
+  '@changesets/assemble-release-plan@6.0.8':
+    resolution: {integrity: sha512-y8+8LvZCkKJdbUlpXFuqcavpzJR80PN0OIfn8HZdwK7Sh6MgLXm4hKY5vu6/NDoKp8lAlM4ERZCqRMLxP4m+MQ==}
 
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/cli@2.29.3':
-    resolution: {integrity: sha512-TNhKr6Loc7I0CSD9LpAyVNSxWBHElXVmmvQYIZQvaMan5jddmL7geo3+08Wi7ImgHFVNB0Nhju/LzXqlrkoOxg==}
+  '@changesets/cli@2.29.4':
+    resolution: {integrity: sha512-VW30x9oiFp/un/80+5jLeWgEU6Btj8IqOgI+X/zAYu4usVOWXjPIK5jSSlt5jsCU7/6Z7AxEkarxBxGUqkAmNg==}
     hasBin: true
 
   '@changesets/config@3.1.1':
@@ -236,8 +236,8 @@ packages:
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
 
-  '@changesets/get-release-plan@4.0.11':
-    resolution: {integrity: sha512-4DZpsewsc/1m5TArVg5h1c0U94am+cJBnu3izAM3yYIZr8+zZwa3AXYdEyCNURzjx0wWr80u/TWoxshbwdZXOA==}
+  '@changesets/get-release-plan@4.0.12':
+    resolution: {integrity: sha512-KukdEgaafnyGryUwpHG2kZ7xJquOmWWWk5mmoeQaSvZTWH1DC5D/Sw6ClgGFYtQnOMSQhgoEbDxAbpIIayKH1g==}
 
   '@changesets/get-version-range-type@0.4.0':
     resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
@@ -789,17 +789,17 @@ packages:
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
-  '@types/node@22.15.12':
-    resolution: {integrity: sha512-K0fpC/ZVeb8G9rm7bH7vI0KAec4XHEhBam616nVJCV51bKzJ6oA3luG4WdKoaztxe70QaNjS/xBmcDLmr4PiGw==}
+  '@types/node@22.15.21':
+    resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@vitest/expect@3.1.3':
-    resolution: {integrity: sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==}
+  '@vitest/expect@3.1.4':
+    resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
 
-  '@vitest/mocker@3.1.3':
-    resolution: {integrity: sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==}
+  '@vitest/mocker@3.1.4':
+    resolution: {integrity: sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -809,25 +809,25 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.1.3':
-    resolution: {integrity: sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==}
+  '@vitest/pretty-format@3.1.4':
+    resolution: {integrity: sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==}
 
-  '@vitest/runner@3.1.3':
-    resolution: {integrity: sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==}
+  '@vitest/runner@3.1.4':
+    resolution: {integrity: sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==}
 
-  '@vitest/snapshot@3.1.3':
-    resolution: {integrity: sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==}
+  '@vitest/snapshot@3.1.4':
+    resolution: {integrity: sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==}
 
-  '@vitest/spy@3.1.3':
-    resolution: {integrity: sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==}
+  '@vitest/spy@3.1.4':
+    resolution: {integrity: sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==}
 
-  '@vitest/ui@3.1.3':
-    resolution: {integrity: sha512-IipSzX+8DptUdXN/GWq3hq5z18MwnpphYdOMm0WndkRGYELzfq7NDP8dMpZT7JGW1uXFrIGxOW2D0Xi++ulByg==}
+  '@vitest/ui@3.1.4':
+    resolution: {integrity: sha512-CFc2Bpb3sz4Sdt53kdNGq+qZKLftBwX4qZLC03CBUc0N1LJrOoL0ZeK0oq/708mtnpwccL0BZCY9d1WuiBSr7Q==}
     peerDependencies:
-      vitest: 3.1.3
+      vitest: 3.1.4
 
-  '@vitest/utils@3.1.3':
-    resolution: {integrity: sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==}
+  '@vitest/utils@3.1.4':
+    resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1954,8 +1954,8 @@ packages:
   utif2@4.1.0:
     resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
 
-  vite-node@3.1.3:
-    resolution: {integrity: sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==}
+  vite-node@3.1.4:
+    resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -2005,16 +2005,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.1.3:
-    resolution: {integrity: sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==}
+  vitest@3.1.4:
+    resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.1.3
-      '@vitest/ui': 3.1.3
+      '@vitest/browser': 3.1.4
+      '@vitest/ui': 3.1.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2251,7 +2251,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.1
 
-  '@changesets/assemble-release-plan@6.0.7':
+  '@changesets/assemble-release-plan@6.0.8':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -2264,15 +2264,15 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.3':
+  '@changesets/cli@2.29.4':
     dependencies:
       '@changesets/apply-release-plan': 7.0.12
-      '@changesets/assemble-release-plan': 6.0.7
+      '@changesets/assemble-release-plan': 6.0.8
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.1
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.11
+      '@changesets/get-release-plan': 4.0.12
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
       '@changesets/pre': 2.0.2
@@ -2316,9 +2316,9 @@ snapshots:
       picocolors: 1.1.1
       semver: 7.7.1
 
-  '@changesets/get-release-plan@4.0.11':
+  '@changesets/get-release-plan@4.0.12':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.7
+      '@changesets/assemble-release-plan': 6.0.8
       '@changesets/config': 3.1.1
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.5
@@ -2868,60 +2868,60 @@ snapshots:
 
   '@types/node@16.9.1': {}
 
-  '@types/node@22.15.12':
+  '@types/node@22.15.21':
     dependencies:
       undici-types: 6.21.0
 
   '@types/unist@3.0.3': {}
 
-  '@vitest/expect@3.1.3':
+  '@vitest/expect@3.1.4':
     dependencies:
-      '@vitest/spy': 3.1.3
-      '@vitest/utils': 3.1.3
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
-      '@vitest/spy': 3.1.3
+      '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
-  '@vitest/pretty-format@3.1.3':
+  '@vitest/pretty-format@3.1.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.1.3':
+  '@vitest/runner@3.1.4':
     dependencies:
-      '@vitest/utils': 3.1.3
+      '@vitest/utils': 3.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@3.1.3':
+  '@vitest/snapshot@3.1.4':
     dependencies:
-      '@vitest/pretty-format': 3.1.3
+      '@vitest/pretty-format': 3.1.4
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.1.3':
+  '@vitest/spy@3.1.4':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/ui@3.1.3(vitest@3.1.3)':
+  '@vitest/ui@3.1.4(vitest@3.1.4)':
     dependencies:
-      '@vitest/utils': 3.1.3
+      '@vitest/utils': 3.1.4
       fflate: 0.8.2
       flatted: 3.3.3
       pathe: 2.0.3
       sirv: 3.0.1
       tinyglobby: 0.2.13
       tinyrainbow: 2.0.0
-      vitest: 3.1.3(@types/node@22.15.12)(@vitest/ui@3.1.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest: 3.1.4(@types/node@22.15.21)(@vitest/ui@3.1.4)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
-  '@vitest/utils@3.1.3':
+  '@vitest/utils@3.1.4':
     dependencies:
-      '@vitest/pretty-format': 3.1.3
+      '@vitest/pretty-format': 3.1.4
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -3995,13 +3995,13 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
-  vite-node@3.1.3(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+  vite-node@3.1.4(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4016,12 +4016,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-babel@1.3.1(@babel/core@7.27.1)(vite@6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)):
+  vite-plugin-babel@1.3.1(@babel/core@7.27.1)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)):
     dependencies:
       '@babel/core': 7.27.1
-      vite: 6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
-  vite@6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+  vite@6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -4030,21 +4030,21 @@ snapshots:
       rollup: 4.40.2
       tinyglobby: 0.2.13
     optionalDependencies:
-      '@types/node': 22.15.12
+      '@types/node': 22.15.21
       fsevents: 2.3.3
       terser: 5.39.0
       tsx: 4.19.4
       yaml: 2.7.1
 
-  vitest@3.1.3(@types/node@22.15.12)(@vitest/ui@3.1.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+  vitest@3.1.4(@types/node@22.15.21)(@vitest/ui@3.1.4)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
-      '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      '@vitest/pretty-format': 3.1.3
-      '@vitest/runner': 3.1.3
-      '@vitest/snapshot': 3.1.3
-      '@vitest/spy': 3.1.3
-      '@vitest/utils': 3.1.3
+      '@vitest/expect': 3.1.4
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.1.4
+      '@vitest/runner': 3.1.4
+      '@vitest/snapshot': 3.1.4
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
       chai: 5.2.0
       debug: 4.4.0
       expect-type: 1.2.1
@@ -4056,12 +4056,12 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      vite-node: 3.1.3(@types/node@22.15.12)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite-node: 3.1.4(@types/node@22.15.21)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.15.12
-      '@vitest/ui': 3.1.3(vitest@3.1.3)
+      '@types/node': 22.15.21
+      '@vitest/ui': 3.1.4(vitest@3.1.4)
     transitivePeerDependencies:
       - jiti
       - less

--- a/tests/__snapshots__/maxicode-1/MODE2/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE2/fast-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 14,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 251,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 251,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 14,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE2/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE2/slow-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 14,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 251,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 251,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 14,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE3/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE3/fast-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 6,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 243,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 243,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 6,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE3/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE3/slow-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 6,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 243,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 243,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 6,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE4/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE4/fast-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 12,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 249,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 249,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 12,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE4/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE4/slow-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 12,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 249,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 249,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 12,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE5/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE5/fast-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 7,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 244,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 244,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 7,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE5/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE5/slow-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 7,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 244,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 244,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 7,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE6/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE6/fast-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 9,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 246,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 246,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 9,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/MODE6/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/MODE6/slow-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 9,
+      "y": 14
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 246,
+      "y": 14
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 246,
+      "y": 244
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 9,
+      "y": 244
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/Wikipedia/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/Wikipedia/fast-0.json
@@ -14,16 +14,16 @@
       "y": 0
     },
     "topRight": {
-      "x": 0,
+      "x": 199,
       "y": 0
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 199,
+      "y": 191
     },
     "bottomLeft": {
       "x": 0,
-      "y": 0
+      "y": 191
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/Wikipedia/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/Wikipedia/slow-0.json
@@ -14,16 +14,16 @@
       "y": 0
     },
     "topRight": {
-      "x": 0,
+      "x": 199,
       "y": 0
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 199,
+      "y": 191
     },
     "bottomLeft": {
       "x": 0,
-      "y": 0
+      "y": 191
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/mode4-mixed-ecis/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/mode4-mixed-ecis/fast-0.json
@@ -10,20 +10,20 @@
   "hasECI": true,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 1
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 1
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 183
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 183
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/mode4-mixed-ecis/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/mode4-mixed-ecis/slow-0.json
@@ -10,20 +10,20 @@
   "hasECI": true,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 1
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 1
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 183
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 183
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/mode4-mixed-sets/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/mode4-mixed-sets/fast-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 1
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 1
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 183
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 183
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/mode4-mixed-sets/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/mode4-mixed-sets/slow-0.json
@@ -10,20 +10,20 @@
   "hasECI": false,
   "position": {
     "topLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 1
     },
     "topRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 1
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 190,
+      "y": 183
     },
     "bottomLeft": {
-      "x": 0,
-      "y": 0
+      "x": 1,
+      "y": 183
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/mode5-sequence2of3/fast-0.json
+++ b/tests/__snapshots__/maxicode-1/mode5-sequence2of3/fast-0.json
@@ -14,16 +14,16 @@
       "y": 0
     },
     "topRight": {
-      "x": 0,
+      "x": 98,
       "y": 0
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 98,
+      "y": 94
     },
     "bottomLeft": {
       "x": 0,
-      "y": 0
+      "y": 94
     }
   },
   "orientation": 0,

--- a/tests/__snapshots__/maxicode-1/mode5-sequence2of3/slow-0.json
+++ b/tests/__snapshots__/maxicode-1/mode5-sequence2of3/slow-0.json
@@ -14,16 +14,16 @@
       "y": 0
     },
     "topRight": {
-      "x": 0,
+      "x": 98,
       "y": 0
     },
     "bottomRight": {
-      "x": 0,
-      "y": 0
+      "x": 98,
+      "y": 94
     },
     "bottomLeft": {
       "x": 0,
-      "y": 0
+      "y": 94
     }
   },
   "orientation": 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved MaxiCode scanning to include position information for pure MaxiCodes.

- **Chores**
  - Updated several development dependencies to their latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->