### PR TITLE
chore: sync zxing-cpp submodule to v3.1.0-rc1-2-g80c040ca

### DIFF
--- a/.changeset/uec-snapshot-update.md
+++ b/.changeset/uec-snapshot-update.md
@@ -1,0 +1,5 @@
+---
+"zxing-wasm": patch
+---
+
+upgrade zxing-cpp to v3.1.0-rc1-2-g80c040ca and update test snapshots for UEC (Unused Error Correction) field

--- a/tests/__snapshots__/micropdf417-1/MPDF-0-p/fast-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0-p/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0-p/fast-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0-p/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0-p/pure-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0-p/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-270.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-90.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0-p/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0/fast-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0/fast-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0/pure-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0/slow-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0/slow-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0/slow-270.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-0/slow-90.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-0/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"48%\"}",
+  "extra": "{\"UEC\":0.88,\"ECLevel\":\"48%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "48%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-1/fast-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-1/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-1/fast-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-1/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-1/pure-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-1/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-1/slow-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-1/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-1/slow-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-1/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-1/slow-270.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-1/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-1/slow-90.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-1/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-2/fast-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-2/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-2/fast-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-2/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-2/slow-0.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-2/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-2/slow-180.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-2/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-2/slow-270.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-2/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/micropdf417-1/MPDF-2/slow-90.json
+++ b/tests/__snapshots__/micropdf417-1/MPDF-2/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"31%\"}",
+  "extra": "{\"UEC\":0.77,\"ECLevel\":\"31%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "31%"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-0.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-0.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-180.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-180.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-270.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-270.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-90.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/fast-90.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/pure-0.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/pure-0.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-0.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-0.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-180.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-180.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-270.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-270.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-90.json
+++ b/tests/__snapshots__/microqrcode-1/M1-Numeric/slow-90.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-0.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-0.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-180.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-180.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-270.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-270.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-90.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/fast-90.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/pure-0.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/pure-0.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-0.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-0.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-180.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-180.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-270.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-270.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-90.json
+++ b/tests/__snapshots__/microqrcode-1/NoQuietZone/slow-90.json
@@ -39,7 +39,7 @@
     "width": 11,
     "height": 11
   },
-  "extra": "{\"DataMask\":2,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
+  "extra": "{\"DataMask\":2,\"UEC\":0.0,\"Version\":\"M1\",\"ECLevel\":\"L\"}",
   "version": "M1",
   "readerInit": false,
   "ecLevel": "L"

--- a/tests/__snapshots__/pdf417-1/01/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/01/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-1/01/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/01/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-1/01/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/01/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-1/01/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/01/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-1/01/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/01/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-1/01/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/01/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-1/01/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/01/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-1/02/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/02/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/02/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/02/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/02/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/02/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/02/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/02/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/02/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/02/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/02/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/02/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/02/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/02/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/03-aliased/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/03-aliased/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-aliased/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/03-aliased/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-aliased/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/03-aliased/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-aliased/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/03-aliased/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-aliased/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/03-aliased/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-aliased/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/03-aliased/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-aliased/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/03-aliased/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-bot/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-bot/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.62,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-bot/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-bot/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.62,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-bot/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-bot/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-bot/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-bot/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.62,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-bot/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-bot/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.62,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-bot/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-bot/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.62,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-bot/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-bot/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.62,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-top/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-top/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-top/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-top/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-top/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-top/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-top/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-top/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-top/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-top/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-top/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-top/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-cut-top/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/03-cut-top/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-flipped/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/03-flipped/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-flipped/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/03-flipped/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-flipped/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/03-flipped/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-flipped/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/03-flipped/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-flipped/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/03-flipped/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-flipped/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/03-flipped/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-flipped/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/03-flipped/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-rot90/fast-270.json
+++ b/tests/__snapshots__/pdf417-1/03-rot90/fast-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-rot90/fast-90.json
+++ b/tests/__snapshots__/pdf417-1/03-rot90/fast-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-rot90/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/03-rot90/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-rot90/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/03-rot90/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-rot90/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/03-rot90/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-rot90/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/03-rot90/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03-rot90/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/03-rot90/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/03/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/03/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/03/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/03/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/03/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/03/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/03/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/03/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"47%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"47%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "47%"

--- a/tests/__snapshots__/pdf417-1/04/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/04/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"23%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"23%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "23%"

--- a/tests/__snapshots__/pdf417-1/04/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/04/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"23%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"23%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "23%"

--- a/tests/__snapshots__/pdf417-1/04/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/04/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"23%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"23%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "23%"

--- a/tests/__snapshots__/pdf417-1/04/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/04/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"23%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"23%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "23%"

--- a/tests/__snapshots__/pdf417-1/04/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/04/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"23%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"23%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "23%"

--- a/tests/__snapshots__/pdf417-1/04/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/04/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"23%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"23%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "23%"

--- a/tests/__snapshots__/pdf417-1/04/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/04/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"23%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"23%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "23%"

--- a/tests/__snapshots__/pdf417-1/05/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/05/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"21%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"21%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "21%"

--- a/tests/__snapshots__/pdf417-1/05/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/05/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"21%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"21%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "21%"

--- a/tests/__snapshots__/pdf417-1/05/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/05/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"21%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"21%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "21%"

--- a/tests/__snapshots__/pdf417-1/05/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/05/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"21%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"21%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "21%"

--- a/tests/__snapshots__/pdf417-1/05/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/05/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"21%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"21%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "21%"

--- a/tests/__snapshots__/pdf417-1/05/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/05/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"21%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"21%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "21%"

--- a/tests/__snapshots__/pdf417-1/05/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/05/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"21%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"21%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "21%"

--- a/tests/__snapshots__/pdf417-1/06/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/06/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.56,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/06/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/06/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.56,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/06/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/06/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.12,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/06/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/06/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.56,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/06/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/06/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.56,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/06/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/06/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.56,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/06/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/06/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.56,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/07/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/07/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/07/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/07/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/07/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/07/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":0.37,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/07/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/07/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/07/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/07/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/07/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/07/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/07/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/07/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"15%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"15%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "15%"

--- a/tests/__snapshots__/pdf417-1/09/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/09/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/09/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/09/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/09/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/09/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/09/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/09/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/09/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/09/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/09/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/09/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/09/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/09/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/10/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/10/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"50%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"50%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "50%"

--- a/tests/__snapshots__/pdf417-1/10/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/10/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"50%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"50%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "50%"

--- a/tests/__snapshots__/pdf417-1/10/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/10/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"50%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"50%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "50%"

--- a/tests/__snapshots__/pdf417-1/10/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/10/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"50%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"50%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "50%"

--- a/tests/__snapshots__/pdf417-1/10/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/10/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"50%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"50%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "50%"

--- a/tests/__snapshots__/pdf417-1/10/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/10/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"50%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"50%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "50%"

--- a/tests/__snapshots__/pdf417-1/11/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/11/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"33%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"33%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "33%"

--- a/tests/__snapshots__/pdf417-1/11/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/11/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"33%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"33%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "33%"

--- a/tests/__snapshots__/pdf417-1/11/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/11/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"33%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"33%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "33%"

--- a/tests/__snapshots__/pdf417-1/11/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/11/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"33%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"33%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "33%"

--- a/tests/__snapshots__/pdf417-1/11/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/11/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"33%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"33%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "33%"

--- a/tests/__snapshots__/pdf417-1/11/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/11/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"33%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"33%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "33%"

--- a/tests/__snapshots__/pdf417-1/11/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/11/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"33%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"33%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "33%"

--- a/tests/__snapshots__/pdf417-1/12-mixed-ecis/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/12-mixed-ecis/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"16%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"16%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "16%"

--- a/tests/__snapshots__/pdf417-1/12-mixed-ecis/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/12-mixed-ecis/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"16%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"16%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "16%"

--- a/tests/__snapshots__/pdf417-1/12-mixed-ecis/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/12-mixed-ecis/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"16%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"16%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "16%"

--- a/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"16%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"16%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "16%"

--- a/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"16%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"16%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "16%"

--- a/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"16%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"16%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "16%"

--- a/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/12-mixed-ecis/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"16%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"16%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "16%"

--- a/tests/__snapshots__/pdf417-1/13-readerinit/fast-0.json
+++ b/tests/__snapshots__/pdf417-1/13-readerinit/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\",\"ReaderInit\":true}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\",\"ReaderInit\":true}",
   "version": "",
   "readerInit": true,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/13-readerinit/fast-180.json
+++ b/tests/__snapshots__/pdf417-1/13-readerinit/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\",\"ReaderInit\":true}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\",\"ReaderInit\":true}",
   "version": "",
   "readerInit": true,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/13-readerinit/pure-0.json
+++ b/tests/__snapshots__/pdf417-1/13-readerinit/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\",\"ReaderInit\":true}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\",\"ReaderInit\":true}",
   "version": "",
   "readerInit": true,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/13-readerinit/slow-0.json
+++ b/tests/__snapshots__/pdf417-1/13-readerinit/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\",\"ReaderInit\":true}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\",\"ReaderInit\":true}",
   "version": "",
   "readerInit": true,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/13-readerinit/slow-180.json
+++ b/tests/__snapshots__/pdf417-1/13-readerinit/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\",\"ReaderInit\":true}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\",\"ReaderInit\":true}",
   "version": "",
   "readerInit": true,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/13-readerinit/slow-270.json
+++ b/tests/__snapshots__/pdf417-1/13-readerinit/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\",\"ReaderInit\":true}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\",\"ReaderInit\":true}",
   "version": "",
   "readerInit": true,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-1/13-readerinit/slow-90.json
+++ b/tests/__snapshots__/pdf417-1/13-readerinit/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"57%\",\"ReaderInit\":true}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"57%\",\"ReaderInit\":true}",
   "version": "",
   "readerInit": true,
   "ecLevel": "57%"

--- a/tests/__snapshots__/pdf417-2/01/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/01/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/01/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/01/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/01/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/01/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/01/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/01/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/01/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/01/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/01/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/01/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/02/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/02/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/02/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/02/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/02/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/02/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/02/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/02/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/02/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/02/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/02/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/02/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/03/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/03/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/03/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/03/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/03/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/03/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/03/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/03/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/03/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/03/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/03/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/03/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/04/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/04/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/04/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/04/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/04/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/04/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/04/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/04/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/04/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/04/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/04/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/04/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/05/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/05/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/05/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/05/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/05/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/05/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/05/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/05/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/05/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/05/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/05/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/05/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/06/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/06/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/06/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/06/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/06/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/06/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/06/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/06/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/06/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/06/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/06/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/06/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/07/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/07/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/07/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/07/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/07/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/07/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/07/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/07/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/07/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/07/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/07/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/07/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"30%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"30%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "30%"

--- a/tests/__snapshots__/pdf417-2/08/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/08/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/08/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/08/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/08/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/08/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/08/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/08/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/08/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/08/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/08/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/08/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/09/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/09/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/09/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/09/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/09/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/09/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/09/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/09/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/09/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/09/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/09/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/09/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/10/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/10/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/10/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/10/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/10/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/10/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/10/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/10/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/10/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/10/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/10/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/10/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/11/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/11/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/11/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/11/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/11/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/11/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/11/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/11/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/11/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/11/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/11/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/11/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/12/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/12/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/12/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/12/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/12/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/12/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/12/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/12/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/12/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/12/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/12/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/12/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/13/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/13/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/13/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/13/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/13/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/13/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/13/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/13/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/13/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/13/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/13/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/13/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/14/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/14/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/14/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/14/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/14/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/14/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/14/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/14/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/14/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/14/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/14/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/14/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/15/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/15/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/15/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/15/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/15/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/15/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/15/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/15/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/15/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/15/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/15/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/15/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"14%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"14%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "14%"

--- a/tests/__snapshots__/pdf417-2/16/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/16/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/16/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/16/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/16/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/16/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/16/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/16/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/16/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/16/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/16/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/16/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/17/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/17/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/17/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/17/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/17/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/17/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/17/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/17/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/17/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/17/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/17/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/17/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/18/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/18/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/18/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/18/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/18/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/18/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/18/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/18/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/18/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/18/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/18/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/18/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.50,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/19/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/19/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/19/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/19/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/19/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/19/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/19/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/19/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/19/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/19/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/19/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/19/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/20/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/20/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/20/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/20/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/20/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/20/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/20/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/20/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/20/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/20/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/20/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/20/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/21/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/21/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/21/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/21/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/21/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/21/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/21/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/21/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/21/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/21/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/21/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/21/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/22/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/22/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/22/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/22/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/22/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/22/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/22/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/22/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/22/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/22/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/22/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/22/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":0.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/23/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/23/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/23/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/23/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/23/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/23/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/23/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/23/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/23/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/23/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/23/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/23/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"9%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"9%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "9%"

--- a/tests/__snapshots__/pdf417-2/24/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/24/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "4%"

--- a/tests/__snapshots__/pdf417-2/24/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/24/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "4%"

--- a/tests/__snapshots__/pdf417-2/24/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/24/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "4%"

--- a/tests/__snapshots__/pdf417-2/24/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/24/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "4%"

--- a/tests/__snapshots__/pdf417-2/24/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/24/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "4%"

--- a/tests/__snapshots__/pdf417-2/24/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/24/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099046122105112\",\"ECLevel\":\"4%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "4%"

--- a/tests/__snapshots__/pdf417-2/25/fast-0.json
+++ b/tests/__snapshots__/pdf417-2/25/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-2/25/fast-180.json
+++ b/tests/__snapshots__/pdf417-2/25/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-2/25/slow-0.json
+++ b/tests/__snapshots__/pdf417-2/25/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-2/25/slow-180.json
+++ b/tests/__snapshots__/pdf417-2/25/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-2/25/slow-270.json
+++ b/tests/__snapshots__/pdf417-2/25/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-2/25/slow-90.json
+++ b/tests/__snapshots__/pdf417-2/25/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"36%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"36%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "36%"

--- a/tests/__snapshots__/pdf417-3/01/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/01/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/01/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/01/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/01/pure-0.json
+++ b/tests/__snapshots__/pdf417-3/01/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/01/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/01/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/01/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/01/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/01/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/01/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/01/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/01/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/02/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/02/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.99,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/02/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/02/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.99,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/02/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/02/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.99,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/02/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/02/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.99,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/02/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/02/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.99,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/02/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/02/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.99,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/03/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/03/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/03/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/03/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/03/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/03/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/03/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/03/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/03/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/03/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/03/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/03/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/04/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/04/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.84,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/04/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/04/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.84,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/04/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/04/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.84,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/04/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/04/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.84,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/04/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/04/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.84,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/04/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/04/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.84,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/05/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/05/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.81,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/05/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/05/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.81,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/05/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/05/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.81,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/05/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/05/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.81,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/05/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/05/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.81,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/05/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/05/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.79,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/06/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/06/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/06/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/06/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/06/pure-0.json
+++ b/tests/__snapshots__/pdf417-3/06/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/06/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/06/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/06/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/06/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/06/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/06/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/06/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/06/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/07/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/07/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/07/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/07/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/07/pure-0.json
+++ b/tests/__snapshots__/pdf417-3/07/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/07/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/07/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/07/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/07/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/07/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/07/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/07/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/07/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/08/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/08/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/08/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/08/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/08/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/08/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/08/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/08/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/08/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/08/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/08/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/08/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/09/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/09/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/09/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/09/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/09/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/09/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/09/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/09/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/09/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/09/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/09/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/09/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.75,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/10/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/10/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.53,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/10/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/10/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.53,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/10/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/10/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.53,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/10/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/10/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.53,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/10/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/10/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.53,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/10/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/10/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":0.53,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/11/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/11/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/11/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/11/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/11/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/11/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/11/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/11/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/11/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/11/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/11/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/11/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"46%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"46%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "46%"

--- a/tests/__snapshots__/pdf417-3/12/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/12/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"24%\"}",
+  "extra": "{\"UEC\":0.78,\"ECLevel\":\"24%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "24%"

--- a/tests/__snapshots__/pdf417-3/12/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/12/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"24%\"}",
+  "extra": "{\"UEC\":0.78,\"ECLevel\":\"24%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "24%"

--- a/tests/__snapshots__/pdf417-3/12/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/12/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"24%\"}",
+  "extra": "{\"UEC\":0.78,\"ECLevel\":\"24%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "24%"

--- a/tests/__snapshots__/pdf417-3/12/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/12/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"24%\"}",
+  "extra": "{\"UEC\":0.78,\"ECLevel\":\"24%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "24%"

--- a/tests/__snapshots__/pdf417-3/12/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/12/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"24%\"}",
+  "extra": "{\"UEC\":0.78,\"ECLevel\":\"24%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "24%"

--- a/tests/__snapshots__/pdf417-3/12/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/12/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"24%\"}",
+  "extra": "{\"UEC\":0.78,\"ECLevel\":\"24%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "24%"

--- a/tests/__snapshots__/pdf417-3/16/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/16/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/16/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/16/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/16/pure-0.json
+++ b/tests/__snapshots__/pdf417-3/16/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/16/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/16/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/16/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/16/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/16/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/16/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/16/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/16/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/17/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/17/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/17/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/17/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/17/pure-0.json
+++ b/tests/__snapshots__/pdf417-3/17/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/17/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/17/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/17/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/17/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/17/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/17/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/17/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/17/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":1.0,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/18/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/18/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.89,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/18/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/18/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.89,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/18/pure-0.json
+++ b/tests/__snapshots__/pdf417-3/18/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.78,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/18/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/18/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.89,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/18/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/18/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.89,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/18/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/18/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.89,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/18/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/18/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"93%\"}",
+  "extra": "{\"UEC\":0.89,\"ECLevel\":\"93%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "93%"

--- a/tests/__snapshots__/pdf417-3/19/fast-0.json
+++ b/tests/__snapshots__/pdf417-3/19/fast-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "7%"

--- a/tests/__snapshots__/pdf417-3/19/fast-180.json
+++ b/tests/__snapshots__/pdf417-3/19/fast-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "7%"

--- a/tests/__snapshots__/pdf417-3/19/pure-0.json
+++ b/tests/__snapshots__/pdf417-3/19/pure-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"ECLevel\":\"7%\"}",
+  "extra": "{\"UEC\":0.25,\"ECLevel\":\"7%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "7%"

--- a/tests/__snapshots__/pdf417-3/19/slow-0.json
+++ b/tests/__snapshots__/pdf417-3/19/slow-0.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "7%"

--- a/tests/__snapshots__/pdf417-3/19/slow-180.json
+++ b/tests/__snapshots__/pdf417-3/19/slow-180.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "7%"

--- a/tests/__snapshots__/pdf417-3/19/slow-270.json
+++ b/tests/__snapshots__/pdf417-3/19/slow-270.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "7%"

--- a/tests/__snapshots__/pdf417-3/19/slow-90.json
+++ b/tests/__snapshots__/pdf417-3/19/slow-90.json
@@ -39,7 +39,7 @@
     "width": 0,
     "height": 0
   },
-  "extra": "{\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
+  "extra": "{\"UEC\":1.0,\"FileId\":\"099061207209\",\"FileName\":\"filename.txt\",\"ECLevel\":\"7%\"}",
   "version": "",
   "readerInit": false,
   "ecLevel": "7%"


### PR DESCRIPTION
Includes ReedSolomon UEC (Unused Error Correction) fix that now correctly reports UEC even when the value is zero. Update all affected test snapshots to include the new UEC field in extra metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Upgraded zxing-cpp to v3.1.0-rc1-2-g80c040ca

* **Tests**
  * Updated test snapshots for Unused Error Correction (UEC) field validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->